### PR TITLE
Clean up leftover template placeholders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ _site
 vendor
 debug.log
 __pycache__
+.DS_Store
 .DS_STORE
 .env*
 package.json

--- a/_data/sources.yaml
+++ b/_data/sources.yaml
@@ -25,7 +25,6 @@
   buttons:
     - type: research-briefing
       link: https://www.nature.com/articles/s41590-025-02226-3
-  repo: greenelab/meta-review
 
 - id: doi:10.4049/jimmunol.212.supp.1468.5593
   remove: true

--- a/_members/nour-almushref.md
+++ b/_members/nour-almushref.md
@@ -3,8 +3,6 @@ name: Nour Almushref, MD
 image: images/headshots/nour.jpg
 role: postdoc
 aliases:
-  - 
-  - 
 links:
   orcid: 0009-0005-5797-7343
 ---

--- a/_members/violet-wu.md
+++ b/_members/violet-wu.md
@@ -3,8 +3,6 @@ name: Violet Wu
 image: images/photo.jpg
 role: phd
 aliases:
-  - 
-  - 
 links:
 ---
 

--- a/_members/yichen-gong.md
+++ b/_members/yichen-gong.md
@@ -3,8 +3,6 @@ name: Yichen Gong
 image: images/headshots/yichen.jpg
 role: phd
 aliases:
-  - 
-  - 
 links:
   linkedin: yichengong0328
   email: yichengong2028@u.northwestern.edu

--- a/_posts/2023-02-23-example-post-3.md
+++ b/_posts/2023-02-23-example-post-3.md
@@ -1,8 +1,0 @@
----
-title: Example post 3
-image: images/photo.jpg
-author: john-doe
-tags: biology, medicine
----
-
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.


### PR DESCRIPTION
- Remove template example blog post (Example post 3, john-doe author)
- Drop stray `repo: greenelab/meta-review` from the featured 2025 paper in sources.yaml (copied from the template's commented example)
- Remove empty `aliases:` list items from three member files
- Add `.DS_Store` (correct case) to .gitignore

This website is based on the Lab Website Template.
See its documentation for working with this site:

https://greene-lab.gitbook.io/lab-website-template-docs
